### PR TITLE
Navigating away from browse error

### DIFF
--- a/components/dapps/list/CountBrowse.vue
+++ b/components/dapps/list/CountBrowse.vue
@@ -25,10 +25,10 @@
   export default {
     beforeDestroy () {
       if (this.categoriesDropdownIsActive === true) {
-        this.toggleBrowseCategories()
+        this.toggle('categories')
       }
       if (this.refineDropdownIsActive === true) {
-        this.toggleBrowseRefine()
+        this.toggle('refine')
       }
     },
     components: {


### PR DESCRIPTION
Fix this.toggleBrowseRefine is not a function.

Error occurs when a user activates the dapps dropdown and navigates away from the page without toggling again.